### PR TITLE
Allow passing params to RocketfuelApi::Service#get_all

### DIFF
--- a/lib/importeur/data_sources/rocketfuel.rb
+++ b/lib/importeur/data_sources/rocketfuel.rb
@@ -3,8 +3,9 @@
 module Importeur
   module DataSources
     class Rocketfuel
-      def initialize(rocketfuel_service)
+      def initialize(rocketfuel_service, params = {})
         @rocketfuel_service = rocketfuel_service
+        @params = params
       end
 
       def dataset_unique_id
@@ -14,12 +15,12 @@ module Importeur
       end
 
       def items
-        @items ||= rocketfuel_service.get_all
+        @items ||= rocketfuel_service.get_all(params)
       end
 
       private
 
-      attr_reader :rocketfuel_service
+      attr_reader :rocketfuel_service, :params
     end
   end
 end

--- a/spec/importeur/data_sources/rocketfuel_spec.rb
+++ b/spec/importeur/data_sources/rocketfuel_spec.rb
@@ -5,17 +5,20 @@ require 'rocketfuel_api'
 RSpec.describe Importeur::DataSources::Rocketfuel do
   subject(:data_source) { described_class.new(rocketfuel_service) }
 
-  let(:rocketfuel_service) { instance_double(RocketfuelApi::Service::Company) }
-  let(:resource_resource)  { instance_double(RocketfuelApi::Resource::Company) }
+  let(:rocketfuel_service)        { instance_double(RocketfuelApi::Service::Company) }
+  let(:company_resource)          { instance_double(RocketfuelApi::Resource::Company) }
+  let(:specific_company_resource) { instance_double(RocketfuelApi::Resource::Company) }
+
+  let(:params) { { 'filter' => 'value' } }
 
   before do
-    allow(rocketfuel_service).to receive(:get_all).and_return([resource_resource])
+    allow(rocketfuel_service).to receive(:get_all).with({}).and_return([company_resource])
+    allow(rocketfuel_service).to receive(:get_all).with(params).and_return([specific_company_resource])
   end
 
   describe '#items' do
     it 'returns items' do
-      expect(data_source.items).to eq([resource_resource])
-      expect(rocketfuel_service).to have_received(:get_all).with({})
+      expect(data_source.items).to eq([company_resource])
     end
   end
 
@@ -28,11 +31,8 @@ RSpec.describe Importeur::DataSources::Rocketfuel do
   context 'with params' do
     subject(:data_source) { described_class.new(rocketfuel_service, params) }
 
-    let(:params) { { 'filter' => 'value' } }
-
     it 'pass params to #get_all and returns items' do
-      expect(data_source.items).to eq([resource_resource])
-      expect(rocketfuel_service).to have_received(:get_all).with(params)
+      expect(data_source.items).to eq([specific_company_resource])
     end
   end
 end

--- a/spec/importeur/data_sources/rocketfuel_spec.rb
+++ b/spec/importeur/data_sources/rocketfuel_spec.rb
@@ -9,18 +9,30 @@ RSpec.describe Importeur::DataSources::Rocketfuel do
   let(:resource_resource)  { instance_double(RocketfuelApi::Resource::Company) }
 
   before do
-    expect(rocketfuel_service).to receive(:get_all).and_return([resource_resource])
+    allow(rocketfuel_service).to receive(:get_all).and_return([resource_resource])
   end
 
   describe '#items' do
     it 'returns items' do
       expect(data_source.items).to eq([resource_resource])
+      expect(rocketfuel_service).to have_received(:get_all).with({})
     end
   end
 
   describe '#dataset_unique_id' do
     it 'returns a hash' do
       expect(data_source.dataset_unique_id).to eq('a321d32f28c72c4723523a586f0424d6')
+    end
+  end
+
+  context 'with params' do
+    subject(:data_source) { described_class.new(rocketfuel_service, params) }
+
+    let(:params) { { 'filter' => 'value' } }
+
+    it 'pass params to #get_all and returns items' do
+      expect(data_source.items).to eq([resource_resource])
+      expect(rocketfuel_service).to have_received(:get_all).with(params)
     end
   end
 end


### PR DESCRIPTION
To import RocketFuel Line Items, it is required to pass `campaign_id` as param to `get_all`.