### PR TITLE
 Use the same technique for lookin up records as for updating them 

### DIFF
--- a/lib/importeur/active_record_postgres_loader.rb
+++ b/lib/importeur/active_record_postgres_loader.rb
@@ -44,7 +44,7 @@ module Importeur
     def records_for_batch(batch_ids)
       model
         .with_deleted
-        .where(primary_key => batch_ids)
+        .joins(batch_lookup_join_sql(batch_ids))
         .index_by(&primary_key)
     end
 
@@ -52,12 +52,16 @@ module Importeur
       # Basically `self.class.model.where.not(primary_key => imported_ids)`, but
       # more efficient in this case.
       model
-        .joins(<<-SQL)
-          LEFT JOIN (SELECT unnest(ARRAY[#{imported_ids.join(',')}]::int[]) AS primary_key) AS imported
-                 ON imported.primary_key = #{model.table_name}.#{primary_key}
-        SQL
+        .joins(batch_lookup_join_sql(imported_ids))
         .where('imported.primary_key' => nil)
         .delete_all
+    end
+
+    def batch_lookup_join_sql(ids)
+      <<-SQL
+        LEFT JOIN (SELECT unnest(ARRAY[#{ids.join(',')}]::int[]) AS primary_key) AS imported
+               ON imported.primary_key = #{model.table_name}.#{primary_key}
+      SQL
     end
   end
 end

--- a/spec/fixtures/vcr/Import_BucketCake_data_into_Postgres/does_not_import_anything_if_there_is_no_new_data.yml
+++ b/spec/fixtures/vcr/Import_BucketCake_data_into_Postgres/does_not_import_anything_if_there_is_no_new_data.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://ad2games-cake-data-test-fixtures.s3-eu-west-1.amazonaws.com/affiliates/latest.gz
+    uri: https://ad2games-cake-data-test-fixtures.s3.eu-west-1.amazonaws.com/affiliates/latest.gz
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -12,16 +12,16 @@ http_interactions:
       Accept-Encoding:
       - ''
       User-Agent:
-      - aws-sdk-ruby3/3.2.0 ruby/2.4.1 x86_64-linux aws-sdk-s3/1.1.0
+      - aws-sdk-ruby3/3.11.0 ruby/2.4.2 x86_64-linux aws-sdk-s3/1.8.0
       Host:
-      - ad2games-cake-data-test-fixtures.s3-eu-west-1.amazonaws.com
+      - ad2games-cake-data-test-fixtures.s3.eu-west-1.amazonaws.com
       X-Amz-Date:
-      - 20170905T152346Z
+      - 20171201T173910Z
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=aws-access-key-id/20170905/eu-west-1/s3/aws4_request,
-        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=8698c6c5361fb06cb76e22be01f1760d637f1690f68e66b38cfceff083410118
+      - AWS4-HMAC-SHA256 Credential=aws-access-key-id/20171201/eu-west-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=d2abf035d5acc122c3f12da2297518c0f984c779928a3b4248a967d08f91c323
       Content-Length:
       - '0'
       Accept:
@@ -32,11 +32,11 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - "/y7g0JTU1cEnBHvzWaxMN4weYM+DP20eqIB9ou5+ZzUOIwZjNfO49OivhQ5YT2QTfv+euCC+CZE="
+      - hfGhqB6OKSZWtCa1MZ9J+W7C3WR04MQldiAOG45zVFXZkbje7xtW5Pf6kI1mAL9bZUncTWeDCQw=
       X-Amz-Request-Id:
-      - EC1EF0F67454963A
+      - 6BBF9C0AA1036061
       Date:
-      - Tue, 05 Sep 2017 15:23:47 GMT
+      - Fri, 01 Dec 2017 17:39:11 GMT
       Last-Modified:
       - Thu, 20 Jul 2017 07:05:59 GMT
       Etag:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 15:23:46 GMT
+  recorded_at: Fri, 01 Dec 2017 17:39:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Import_BucketCake_data_into_Postgres/imports_data.yml
+++ b/spec/fixtures/vcr/Import_BucketCake_data_into_Postgres/imports_data.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://ad2games-cake-data-test-fixtures.s3-eu-west-1.amazonaws.com/affiliates/latest.gz
+    uri: https://ad2games-cake-data-test-fixtures.s3.eu-west-1.amazonaws.com/affiliates/latest.gz
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -12,16 +12,16 @@ http_interactions:
       Accept-Encoding:
       - ''
       User-Agent:
-      - aws-sdk-ruby3/3.2.0 ruby/2.4.1 x86_64-linux aws-sdk-s3/1.1.0
+      - aws-sdk-ruby3/3.11.0 ruby/2.4.2 x86_64-linux aws-sdk-s3/1.8.0
       Host:
-      - ad2games-cake-data-test-fixtures.s3-eu-west-1.amazonaws.com
+      - ad2games-cake-data-test-fixtures.s3.eu-west-1.amazonaws.com
       X-Amz-Date:
-      - 20170905T152344Z
+      - 20171201T173909Z
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=aws-access-key-id/20170905/eu-west-1/s3/aws4_request,
-        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=548fa417f4dc31eb937af8ea6f9b569775dfa5a851ba62dab38f9aabf0ad3b1e
+      - AWS4-HMAC-SHA256 Credential=aws-access-key-id/20171201/eu-west-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=bc5100e77035e002fce5334df1660711965ac0063588f99847eaed4632a9f593
       Content-Length:
       - '0'
       Accept:
@@ -32,11 +32,11 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - H5coCT0167Gxvd4SjJQJ64jXhQUrxkFwSyu5ELSQA2Zz3y9Xyz2msP1x7qYAW3z0EZpbILUlIOk=
+      - c2JgoT/qTu8WfC/TNb4TUWQrJLeppSQz8tlAH4jcV7iwv64ArtTReIp7NrsPFWqEg++VZ6FxrAc=
       X-Amz-Request-Id:
-      - 1A1CCADF526021E6
+      - 623A0E4307D5B83A
       Date:
-      - Tue, 05 Sep 2017 15:23:45 GMT
+      - Fri, 01 Dec 2017 17:39:11 GMT
       Last-Modified:
       - Thu, 20 Jul 2017 07:05:59 GMT
       Etag:
@@ -53,10 +53,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 15:23:46 GMT
+  recorded_at: Fri, 01 Dec 2017 17:39:10 GMT
 - request:
     method: get
-    uri: https://ad2games-cake-data-test-fixtures.s3-eu-west-1.amazonaws.com/affiliates/latest.gz
+    uri: https://ad2games-cake-data-test-fixtures.s3.eu-west-1.amazonaws.com/affiliates/latest.gz
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -66,16 +66,16 @@ http_interactions:
       Accept-Encoding:
       - ''
       User-Agent:
-      - aws-sdk-ruby3/3.2.0 ruby/2.4.1 x86_64-linux aws-sdk-s3/1.1.0
+      - aws-sdk-ruby3/3.11.0 ruby/2.4.2 x86_64-linux aws-sdk-s3/1.8.0
       Host:
-      - ad2games-cake-data-test-fixtures.s3-eu-west-1.amazonaws.com
+      - ad2games-cake-data-test-fixtures.s3.eu-west-1.amazonaws.com
       X-Amz-Date:
-      - 20170905T152346Z
+      - 20171201T173910Z
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=aws-access-key-id/20170905/eu-west-1/s3/aws4_request,
-        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=0cc48d5af1390a7c182120d42fe852755309fa6b2b12a8e60f7b6dfb45267056
+      - AWS4-HMAC-SHA256 Credential=aws-access-key-id/20171201/eu-west-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=22375326a84757225f1647a67a7d70acd15b426007f734be4ba1cffd2e96e469
       Content-Length:
       - '0'
       Accept:
@@ -86,11 +86,11 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - L806GQwCu4McoH2Jnmkhi3afDU/2xzWIjlHH6EO/TNmip8HJ0dqaphUJmUr35hAhH7NfZZ3sMj0=
+      - nESn3HRmbbt7aJzcA/ZGiA5zYtKaH6NWzF2ONDnuz7gngRwU4T4BvKGFbQjWnXv2IaJ0bdhPOrk=
       X-Amz-Request-Id:
-      - 2ED5156F00EBA1F2
+      - A034C63414A2143A
       Date:
-      - Tue, 05 Sep 2017 15:23:47 GMT
+      - Fri, 01 Dec 2017 17:39:11 GMT
       Last-Modified:
       - Thu, 20 Jul 2017 07:05:59 GMT
       Etag:
@@ -108,5 +108,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAA/4SUT3PrJhTF9/0q3SApSuMlYEAothKhCAQ7IaVgG/15z7EV+dN3nNe+eYtOC8s7c++Z3z3n4v38O/FotHHh27h2WpmhVZ+zbkRgbuLQcyZYWI0qAPeOfwf7isT0tB96b5W8cSJCP8izTVDoxv037BwiziCdiLkf6hWNBegGGfrtlHWJWI2SYH/iRMcBvNcT7RLheyYrmMxzR6dMx5vIjmJ9V7xqMwG67XTdxfJBq2ixrL7YJB9brzkUnJaxDzo+tzhB/l1FwY5itoO5dtOC8C6nxAOOEDelKo42kZceo0Kr1JtYrhz7shvCh27y9FlMBYa6wjUdzBDOraLAVJyZeHPU6iM8u3C0cQr0ncGWryQToUsENI33tkFnU6VHG4NH1Ii5Z5+hdCaxSf69Y/4ZsSJY9lnB2Ph3OuWtim6myeNWFUE7M1uV3jlOsOHUDhtgmuJxuxw9FPz5n/k9k7eec4SWO9tiWxP2DMWebz85K5VIdJMHBk8HVIcPrfpwcsRhWlcZCZeeydUOEnCs3VucnluVBk7osWchbhsxm+algmLisSMVlWY2TF45+Xu3GHy8HlCmVRS6dEJkmbCU+2or5aVtRDAYvfWMAtO8eFjCHw8H+K3Mitv+64PXPzhCoLjaBnk7Do+w9EA3/mgZvXVPHKFG+HcWTiskCDhCWpV7e+GIuMNrh3ihVbmamH6YZu/kncPLhHCWBzPItRvo+cmRHYb7CoHoakcx2Wx8hKK++wPlaMql3DvBNmfL6MpdIWtQYXio7772NaMpZ7/uHM32gK5mMKE79DfOiqgb82CHIj1Ajk6QowFyNEGOzo4P2H1OfSaWl8PTtWPhwailpcyDPoOPu3Wz2KQAeqDHdv3yx5VnlwfoMgynEmGv+WlcKqL6q47pd1MhbzITulHMXSxX4gl/oHW1ZT/rP3T5Sf5XZp/vQgXvxJj7XpVuV6Fb3xRLq4rZJvLGM3kzDf8wjAL9xrM7O3grl2I7Sfy6/ThYTomLaN/k147V13KQq2XhsrjnP2E5KZznT8TTX2aL2DQ5aJsidJ6/4RcqiUt/1m1sBtNwt/8f3dyd+be1rtBYRHqggzlMDsO7h82qG3niGLgukbeOhWOrNlG3oujOaafu94Os5Csbm8yyzUGrxdWDPLVNHnRSPtLyuESblxUJXohGrvdbtQN56IbP2Z4nnI1ibaONN9t8/PL6mn7lziq6trEErUrH3ZCGvoAY9g7Dd4jh+4RpeXiNHuJ/73vlGKn0es/ub38FAAD//70q5lNlBQAA
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 15:23:46 GMT
+  recorded_at: Fri, 01 Dec 2017 17:39:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Import_BucketCake_data_into_Postgres/with_existing_data/updates_data_that_changed.yml
+++ b/spec/fixtures/vcr/Import_BucketCake_data_into_Postgres/with_existing_data/updates_data_that_changed.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://ad2games-cake-data-test-fixtures.s3-eu-west-1.amazonaws.com/affiliates/latest.gz
+    uri: https://ad2games-cake-data-test-fixtures.s3.eu-west-1.amazonaws.com/affiliates/latest.gz
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -12,16 +12,16 @@ http_interactions:
       Accept-Encoding:
       - ''
       User-Agent:
-      - aws-sdk-ruby3/3.2.0 ruby/2.4.1 x86_64-linux aws-sdk-s3/1.1.0
+      - aws-sdk-ruby3/3.11.0 ruby/2.4.2 x86_64-linux aws-sdk-s3/1.8.0
       Host:
-      - ad2games-cake-data-test-fixtures.s3-eu-west-1.amazonaws.com
+      - ad2games-cake-data-test-fixtures.s3.eu-west-1.amazonaws.com
       X-Amz-Date:
-      - 20170905T152346Z
+      - 20171201T173910Z
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=aws-access-key-id/20170905/eu-west-1/s3/aws4_request,
-        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=8698c6c5361fb06cb76e22be01f1760d637f1690f68e66b38cfceff083410118
+      - AWS4-HMAC-SHA256 Credential=aws-access-key-id/20171201/eu-west-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=d2abf035d5acc122c3f12da2297518c0f984c779928a3b4248a967d08f91c323
       Content-Length:
       - '0'
       Accept:
@@ -32,11 +32,11 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - RlGrb9HiGe8XcKuvZCG814VAQLCzv0TnoNClTwc4kPjZBiKywqxIit7pt1uoJsocEQBqrXTZ+5M=
+      - gFBPqb6WbdiKziYuhAFtX9dSn5MiLCAyaV2mdLWjJysXz1eJ55bORUexTgN7hOqV22G3RyrhrPY=
       X-Amz-Request-Id:
-      - 64DFB0A1AC2EF42A
+      - 11591E1E444832B8
       Date:
-      - Tue, 05 Sep 2017 15:23:47 GMT
+      - Fri, 01 Dec 2017 17:39:11 GMT
       Last-Modified:
       - Thu, 20 Jul 2017 07:05:59 GMT
       Etag:
@@ -53,10 +53,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 15:23:46 GMT
+  recorded_at: Fri, 01 Dec 2017 17:39:10 GMT
 - request:
     method: get
-    uri: https://ad2games-cake-data-test-fixtures.s3-eu-west-1.amazonaws.com/affiliates/latest.gz
+    uri: https://ad2games-cake-data-test-fixtures.s3.eu-west-1.amazonaws.com/affiliates/latest.gz
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -66,16 +66,16 @@ http_interactions:
       Accept-Encoding:
       - ''
       User-Agent:
-      - aws-sdk-ruby3/3.2.0 ruby/2.4.1 x86_64-linux aws-sdk-s3/1.1.0
+      - aws-sdk-ruby3/3.11.0 ruby/2.4.2 x86_64-linux aws-sdk-s3/1.8.0
       Host:
-      - ad2games-cake-data-test-fixtures.s3-eu-west-1.amazonaws.com
+      - ad2games-cake-data-test-fixtures.s3.eu-west-1.amazonaws.com
       X-Amz-Date:
-      - 20170905T152346Z
+      - 20171201T173910Z
       X-Amz-Content-Sha256:
       - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=aws-access-key-id/20170905/eu-west-1/s3/aws4_request,
-        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=0cc48d5af1390a7c182120d42fe852755309fa6b2b12a8e60f7b6dfb45267056
+      - AWS4-HMAC-SHA256 Credential=aws-access-key-id/20171201/eu-west-1/s3/aws4_request,
+        SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=22375326a84757225f1647a67a7d70acd15b426007f734be4ba1cffd2e96e469
       Content-Length:
       - '0'
       Accept:
@@ -86,11 +86,11 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - yiTdNoWp/xJ7h+kmORJBsSKhPu2uHQXuC4zH6VBbFOahiaTUlnpaT4c7zo+XeBIZ/gSuXylsFRo=
+      - F0eMXJC9xj6JrJ75cLJHB2gaazq5xRhcoAegTCrDWsmhuDJJ6sxkYgzXGjaUbXkaFQjoyEIxyZc=
       X-Amz-Request-Id:
-      - A151CF46AD1B3A9A
+      - 2B036AA6876B4381
       Date:
-      - Tue, 05 Sep 2017 15:23:47 GMT
+      - Fri, 01 Dec 2017 17:39:11 GMT
       Last-Modified:
       - Thu, 20 Jul 2017 07:05:59 GMT
       Etag:
@@ -108,5 +108,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAA/4SUT3PrJhTF9/0q3SApSuMlYEAothKhCAQ7IaVgG/15z7EV+dN3nNe+eYtOC8s7c++Z3z3n4v38O/FotHHh27h2WpmhVZ+zbkRgbuLQcyZYWI0qAPeOfwf7isT0tB96b5W8cSJCP8izTVDoxv037BwiziCdiLkf6hWNBegGGfrtlHWJWI2SYH/iRMcBvNcT7RLheyYrmMxzR6dMx5vIjmJ9V7xqMwG67XTdxfJBq2ixrL7YJB9brzkUnJaxDzo+tzhB/l1FwY5itoO5dtOC8C6nxAOOEDelKo42kZceo0Kr1JtYrhz7shvCh27y9FlMBYa6wjUdzBDOraLAVJyZeHPU6iM8u3C0cQr0ncGWryQToUsENI33tkFnU6VHG4NH1Ii5Z5+hdCaxSf69Y/4ZsSJY9lnB2Ph3OuWtim6myeNWFUE7M1uV3jlOsOHUDhtgmuJxuxw9FPz5n/k9k7eec4SWO9tiWxP2DMWebz85K5VIdJMHBk8HVIcPrfpwcsRhWlcZCZeeydUOEnCs3VucnluVBk7osWchbhsxm+algmLisSMVlWY2TF45+Xu3GHy8HlCmVRS6dEJkmbCU+2or5aVtRDAYvfWMAtO8eFjCHw8H+K3Mitv+64PXPzhCoLjaBnk7Do+w9EA3/mgZvXVPHKFG+HcWTiskCDhCWpV7e+GIuMNrh3ihVbmamH6YZu/kncPLhHCWBzPItRvo+cmRHYb7CoHoakcx2Wx8hKK++wPlaMql3DvBNmfL6MpdIWtQYXio7772NaMpZ7/uHM32gK5mMKE79DfOiqgb82CHIj1Ajk6QowFyNEGOzo4P2H1OfSaWl8PTtWPhwailpcyDPoOPu3Wz2KQAeqDHdv3yx5VnlwfoMgynEmGv+WlcKqL6q47pd1MhbzITulHMXSxX4gl/oHW1ZT/rP3T5Sf5XZp/vQgXvxJj7XpVuV6Fb3xRLq4rZJvLGM3kzDf8wjAL9xrM7O3grl2I7Sfy6/ThYTomLaN/k147V13KQq2XhsrjnP2E5KZznT8TTX2aL2DQ5aJsidJ6/4RcqiUt/1m1sBtNwt/8f3dyd+be1rtBYRHqggzlMDsO7h82qG3niGLgukbeOhWOrNlG3oujOaafu94Os5Csbm8yyzUGrxdWDPLVNHnRSPtLyuESblxUJXohGrvdbtQN56IbP2Z4nnI1ibaONN9t8/PL6mn7lziq6trEErUrH3ZCGvoAY9g7Dd4jh+4RpeXiNHuJ/73vlGKn0es/ub38FAAD//70q5lNlBQAA
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 15:23:46 GMT
+  recorded_at: Fri, 01 Dec 2017 17:39:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/importeur/active_record_postgres_loader_spec.rb
+++ b/spec/importeur/active_record_postgres_loader_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Importeur::ActiveRecordPostgresLoader do
     expect(lookup_relation)
       .to receive(:joins)
       .with(<<-SQL)
-        LEFT JOIN (SELECT unnest(ARRAY[1,2]::int[]) AS primary_key) AS imported
-               ON imported.primary_key = cake_offers.id
+        INNER JOIN (SELECT unnest(ARRAY[1,2]::int[]) AS primary_key) AS imported
+                  ON imported.primary_key = cake_offers.id
       SQL
       .and_return(records)
     expect(Time).to receive(:now).and_return(now)
@@ -64,7 +64,7 @@ RSpec.describe Importeur::ActiveRecordPostgresLoader do
       .to receive(:joins)
       .with(<<-SQL)
         LEFT JOIN (SELECT unnest(ARRAY[1,2]::int[]) AS primary_key) AS imported
-               ON imported.primary_key = cake_offers.id
+                  ON imported.primary_key = cake_offers.id
       SQL
       .and_return(deletion_relation)
     expect(deletion_relation)

--- a/spec/importeur/active_record_postgres_loader_spec.rb
+++ b/spec/importeur/active_record_postgres_loader_spec.rb
@@ -39,7 +39,13 @@ RSpec.describe Importeur::ActiveRecordPostgresLoader do
 
   it 'only updates records that changed' do
     expect(model).to receive(:with_deleted).and_return(lookup_relation)
-    expect(lookup_relation).to receive(:where).with(id: [1, 2]).and_return(records)
+    expect(lookup_relation)
+      .to receive(:joins)
+      .with(<<-SQL)
+        LEFT JOIN (SELECT unnest(ARRAY[1,2]::int[]) AS primary_key) AS imported
+               ON imported.primary_key = cake_offers.id
+      SQL
+      .and_return(records)
     expect(Time).to receive(:now).and_return(now)
 
     expect(records.first).to receive(:assign_attributes).with(id: 1, name: 'My Name')
@@ -54,7 +60,13 @@ RSpec.describe Importeur::ActiveRecordPostgresLoader do
     expect(records.last).not_to receive(:imported_at=)
     expect(records.last).not_to receive(:save!)
 
-    expect(model).to receive(:joins).and_return(deletion_relation)
+    expect(model)
+      .to receive(:joins)
+      .with(<<-SQL)
+        LEFT JOIN (SELECT unnest(ARRAY[1,2]::int[]) AS primary_key) AS imported
+               ON imported.primary_key = cake_offers.id
+      SQL
+      .and_return(deletion_relation)
     expect(deletion_relation)
       .to receive(:where)
       .with('imported.primary_key' => nil)

--- a/spec/importeur/data_sources/rocketfuel_spec.rb
+++ b/spec/importeur/data_sources/rocketfuel_spec.rb
@@ -12,8 +12,14 @@ RSpec.describe Importeur::DataSources::Rocketfuel do
   let(:params) { { 'filter' => 'value' } }
 
   before do
-    allow(rocketfuel_service).to receive(:get_all).with({}).and_return([company_resource])
-    allow(rocketfuel_service).to receive(:get_all).with(params).and_return([specific_company_resource])
+    allow(rocketfuel_service)
+      .to receive(:get_all)
+      .with({})
+      .and_return([company_resource])
+    allow(rocketfuel_service)
+      .to receive(:get_all)
+      .with(params)
+      .and_return([specific_company_resource])
   end
 
   describe '#items' do


### PR DESCRIPTION
Currently we have an issue with importing creatives from CAKE into the nevaly backoffice, as looking up the records takes more than 30 seconds per batch. According to `EXPLAIN ANALYZE`, this optimization speeds up the lookup by a factor of 5.