### PR TITLE
Allow transformer to skip entries by returning `nil` or `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Add
+- Allow transformer to skip entries by returning `nil` or `false`. 
 
 ## [0.1.1] - 2018-01-31
 ### Changed

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Importeur::ETL.new(
 All three only need to have a `call` method and, hence, can be simple Procs.
 The extractor should return something enumerable, which is then iterated over
 and each item passed into the transformer. The loader receives the enumerable
-result of that.
+result of that. If the transformer returns `nil` or `false` that element is 
+skipped and not received by the loader. The transformer can also return an 
+array of elements, so a single element from extractor can be received as 
+multiple elements by the loader.
 
 So far a more or less generic `Extractor` exists.
 

--- a/lib/importeur/etl.rb
+++ b/lib/importeur/etl.rb
@@ -12,7 +12,7 @@ module Importeur
       extracted = extractor.call
       return if extracted.nil?
       transformed = extracted.lazy.flat_map do |entity|
-        transformer.call(entity)
+        transformer.call(entity) || []
       end
       loader.call(transformed.lazy)
     end

--- a/spec/importeur/etl_spec.rb
+++ b/spec/importeur/etl_spec.rb
@@ -13,20 +13,30 @@ RSpec.describe Importeur::ETL do
   let(:transformer) { instance_double(Proc) }
   let(:loader) { instance_double(Proc) }
 
-  let(:extracted_item) { instance_double(Object) }
-  let(:transformed_item) { instance_double(Hash) }
+  let(:extracted_item_1) { instance_double(Object) }
+  let(:extracted_item_2) { instance_double(Object) }
+  let(:extracted_item_3) { instance_double(Object) }
+  let(:transformed_item_1) { instance_double(Hash) }
+  let(:transformed_item_2) { nil }
+  let(:transformed_item_3) { instance_double(Hash) }
 
   context 'with new data' do
     before do
-      allow(extractor).to receive(:call).and_return([extracted_item].to_enum)
+      allow(extractor).to receive(:call).and_return(
+        [extracted_item_1, extracted_item_2, extracted_item_3].to_enum
+      )
     end
 
     it 'runs the extract, transform and load steps' do
-      expect(transformer).to receive(:call).with(extracted_item)
-        .and_return(transformed_item)
+      expect(transformer).to receive(:call).with(extracted_item_1)
+        .and_return(transformed_item_1)
+      expect(transformer).to receive(:call).with(extracted_item_2)
+        .and_return(transformed_item_2)
+      expect(transformer).to receive(:call).with(extracted_item_3)
+        .and_return(transformed_item_3)
       expect(loader).to receive(:call) do |arg|
         expect(arg).to be_a(Enumerator::Lazy)
-        expect(arg.to_a).to eq([transformed_item])
+        expect(arg.to_a).to eq([transformed_item_1, transformed_item_3])
       end
 
       etl.call


### PR DESCRIPTION
I needed to skip some elements in transform phase, so I added this feature.

When implementing it here I just noticed that it was already possible to do that by returning and empty array in transformer, but I decided to still add the feature here as returning `nil` is more obvious for the API consumer.